### PR TITLE
Migration dart2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@
 
 A library for Dart developers. It is awesome.
 
+## Dart 2
+
+Take note that this repository is now set to use dart2 tools with flutter. Commands like ```pub build, pub test``` are no longer supported. Please use ```build runner``` now!
+
+```
+❯ pub run build_runner test 
+```
+
 ## Usage
 
 A simple usage example:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,12 +3,14 @@ description: Shared components for Comiko.
 version: 0.0.1
 
 environment:
-  sdk: '>=1.24.1 <2.1.0'
+  sdk: ">=1.24.1 <2.1.0"
 
 dependencies:
-  json_annotation: ^0.2.2
+  json_annotation: "^1.1.0"
 
 dev_dependencies:
-  json_serializable: "^0.3.1"
-  build_runner: ^0.7.4
-  test: ^0.12.30
+  json_serializable: "^1.2.1"
+  build_runner: "^0.10.1+1"
+  build_test: "0.10.3+1"
+  test: "^1.3.0"
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Shared components for Comiko.
 version: 0.0.1
 
 environment:
-  sdk: ">=1.24.1 <2.1.0"
+  sdk: ">=2.0.0 <3.0.0"
 
 dependencies:
   json_annotation: "^1.1.0"

--- a/test/models/event_test.dart
+++ b/test/models/event_test.dart
@@ -1,11 +1,12 @@
 import 'dart:convert';
+
 import 'package:test/test.dart';
 
 import 'package:comiko_shared/models.dart';
 
 main() {
   test('JSON deserialization works for event', () {
-    var json = """
+    var jsonContent = """
       {
         "id": 1,
         "name": "Eh lala..!",
@@ -19,7 +20,7 @@ main() {
         "styles": ""
       }
     """;
-    var jsonMap = JSON.decode(json);
+    var jsonMap = json.decode(jsonContent);
     var model = new Event.fromJson(jsonMap);
 
     expect(model.name, 'Eh lala..!');


### PR DESCRIPTION
Update dependencies to fit SDK 2.1.0+

Fix deprecated JSON term in the tests

Take note that flutter test/build is no longer a valid tool
❯ pub run build_runner test 
